### PR TITLE
don't add fuel_emissions_multiplier to items that don't have a fuel_value

### DIFF
--- a/Bio_Industries/libs/bi_functions.lua
+++ b/Bio_Industries/libs/bi_functions.lua
@@ -19,10 +19,9 @@ end
 
 
 function BI_Functions.lib.fuel_emissions_multiplier_update(item2update, value)
-
-	if data.raw.item[item2update] then	
-		data.raw.item[item2update].fuel_emissions_multiplier = value
+	local target = data.raw.item[item2update]
+	if target and target.fuel_value then
+		target.fuel_emissions_multiplier = value
 	end
-	
 end
 


### PR DESCRIPTION
Applies particularly to pymods ash. Without this safeguard the game refuses to load.